### PR TITLE
fix composer package name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "hall-of-fame",
+    "name": "the-league/hall-of-fame",
     "type": "project",
     "description": "The hall-of-fame project.",
     "keywords": [


### PR DESCRIPTION
Fixes 

```
  "./composer.json" does not match the expected JSON schema:
   - name : Does not match the regex pattern ^[a-z0-9]([_.-]?[a-z0-9]+)*/[a-z0-9](([_.]|-{1,2})?[a-z0-9]+)*$
```